### PR TITLE
fix typos in Docker X11-unix sharing instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ Option 2. **XMing or Cygwin/X**
      ```bash
      sudo systemctl start docker
      ```
-2. **Share X11-unix path to Docker**
-   - Launch Docker
-   - Navigate to to `Settings` → `Resources` → `File sharing`.
-   - In the `Virtual file shares` section, add the following path: '/tmp/.X11-unix'
-   - Apply and restart the docker
+2. **Share X11-unix path with Docker**
+   - Launch Docker.
+   - Navigate to `Settings` → `Resources` → `File sharing`.
+   - In the `Virtual file shares` section, add the following path: '/tmp/.X11-unix'.
+   - Apply and restart the docker.
 
 
 


### PR DESCRIPTION
#### Linux ####

1. **Launch Docker**
   - Ensure that Docker is installed and running on your Linux distribution.
   - Open your terminal and start Docker if it's not already running:
     ```bash
     sudo systemctl start docker
     ```
2. **Share X11-unix path with Docker**
   - Launch Docker.
   - Navigate to `Settings` → `Resources` → `File sharing`.
   - In the `Virtual file shares` section, add the following path: '/tmp/.X11-unix'.
   - Apply and restart the docker.
